### PR TITLE
Fix NPE when another plugin calls an EntityDeathEvent on a Sentry.

### DIFF
--- a/src/net/aufdemrand/sentry/SentryInstance.java
+++ b/src/net/aufdemrand/sentry/SentryInstance.java
@@ -985,14 +985,14 @@ public class SentryInstance {
 
 	public void onDamage(EntityDamageByEntityEvent event) {
 
-		event.setCancelled(true);
-		myNPC.getBukkitEntity().setLastDamageCause(event);
-		if(sentryStatus == Status.isDYING) return;
-
 		if (!myNPC.isSpawned()) {
 			// \\how did youg get here?
 			return;
 		}
+		
+		event.setCancelled(true);
+		myNPC.getBukkitEntity().setLastDamageCause(event);
+		if(sentryStatus == Status.isDYING) return;
 
 		if (guardTarget != null && guardEntity == null) return; //dont take damage when bodyguard target isnt around.
 


### PR DESCRIPTION
Hi jrbudda. Please add this. It fixes an incompatibility with Denizen.
